### PR TITLE
Fix silent Discord channel crash on Windows

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -272,7 +272,11 @@ async function gatewayStart() {
     process.stderr.write(`${C}[gateway]${X} ${d}`);
   });
 
+  let childExited = false;
+  let exitCode: number | null = null;
   child.on("exit", (code) => {
+    childExited = true;
+    exitCode = code;
     clearGatewayPID();
     if (code !== 0) {
       err(`Gateway exited with code ${code}`);
@@ -281,7 +285,10 @@ async function gatewayStart() {
 
   // Brief delay to check startup
   setTimeout(() => {
-    if (getGatewayPID()) {
+    if (childExited) {
+      // Child already exited, don't report success
+      err(`Gateway failed to start (exit code ${exitCode})`);
+    } else if (getGatewayPID()) {
       ok(`Gateway running (PID ${child.pid})`);
     }
   }, 2000);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,18 @@
 import { startDiscord } from "./channels/discord.ts";
 import { startIRC } from "./channels/irc.ts";
 
-// Start enabled channels
-await startDiscord();
-await startIRC();
+// Start enabled channels with error handling
+try {
+    await startDiscord();
+} catch (err: any) {
+    console.error(`Discord channel failed to start: ${err.message}`);
+    // Exit with error code to indicate failure
+    process.exit(1);
+}
+
+try {
+    await startIRC();
+} catch (err: any) {
+    console.error(`IRC channel failed to start: ${err.message}`);
+    // Don't exit if only IRC fails, but log error
+}


### PR DESCRIPTION
This PR addresses the silent crash when starting the gateway on Windows. The Discord channel may fail to start (e.g., missing token, invalid config, or other error), causing the child process to exit immediately while the parent still reports success.

Changes:

1. **src/index.ts**: Added try-catch around  and  to catch errors, log them, and exit with error code. This ensures the child process exits with non-zero code on failure.

2. **src/cli.ts**: Modified  to track child process exit. If the child exits before the 2-second startup check, the parent will log an error instead of falsely reporting success.

These changes should make startup failures visible: the parent will print "Gateway failed to start (exit code X)" and the child's stderr (including the error message) will be printed with the  prefix.

This should help diagnose the issue where dolkip sees "Gateway running (PID ...)" but the gateway is not actually running.