### PR TITLE
Add keep-alive and debug logging to diagnose Windows crash

### DIFF
--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -31,6 +31,9 @@ const client = new Client({
         GatewayIntentBits.GuildMessageReactions,
     ],
 });
+client.on('debug', (msg) => console.log(`[Discord debug] ${msg}`));
+client.on('warn', (msg) => console.warn(`[Discord warn] ${msg}`));
+client.on('error', (err) => console.error(`[Discord error] ${err.message}`));
 
 const EYES = "👀";
 const THINKING = "🤔";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,15 @@
 import { startDiscord } from "./channels/discord.ts";
 import { startIRC } from "./channels/irc.ts";
 
+console.log("Starting gateway channels...");
+
+// Keep process alive
+const keepAlive = setInterval(() => {}, 60_000);
+
 // Start enabled channels with error handling
 try {
     await startDiscord();
+    console.log("Discord channel started");
 } catch (err: any) {
     console.error(`Discord channel failed to start: ${err.message}`);
     // Exit with error code to indicate failure
@@ -12,7 +18,10 @@ try {
 
 try {
     await startIRC();
+    console.log("IRC channel started");
 } catch (err: any) {
     console.error(`IRC channel failed to start: ${err.message}`);
     // Don't exit if only IRC fails, but log error
 }
+
+console.log("All channels started. Gateway running.");


### PR DESCRIPTION
This PR adds a keep-alive interval and extra logging to prevent the gateway process from exiting prematurely on Windows, and to help diagnose why the Discord channel fails to start.

Changes:
1. src/index.ts: Added a keep-alive interval and console.log statements to track channel startup.
2. src/channels/discord.ts: Added debug/warn/error event listeners for Discord.js client.

With these changes, the child process should stay alive longer, and any debug output from Discord.js will be logged to stderr (prefixed with [Discord debug] etc.), which the parent gateway process will capture and print.