### PR TITLE
Fix provider selection and reasoning toggle

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,5 +1,5 @@
 import { handleToolCall } from "./tools.ts";
-import { getApiBaseUrl, getApiKey, getModelId, getTools, type OpoclawConfig } from "./config.ts";
+import { getApiBaseUrl, getApiKey, getModelId, getTools, getActiveProvider, type OpoclawConfig } from "./config.ts";
 import { dirname, join } from "path";
 import { mkdir } from "fs/promises";
 import { fileURLToPath } from "url";
@@ -248,8 +248,8 @@ async function streamCompletion(
         stream: true,
     };
 
-    // Add reasoning toggle
-    if (config.enable_reasoning) {
+    // Add reasoning toggle (only supported by OpenRouter)
+    if (config.enable_reasoning && getActiveProvider(config) === "openrouter") {
         body.reasoning = { enabled: true };
     }
 

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -20,7 +20,7 @@ import { runAgent, type Message as ChatMessage, type ToolCall } from "../agent.t
 import { getFilePath } from "../workspace.ts";
 import { pendingFileSend, clearPendingFileSend } from "../tools.ts";
 
-import { getSemanticSearchEnabled, loadConfig, useTomlFiles } from "../config.ts";
+import { getSemanticSearchEnabled, loadConfig, useTomlFiles, getActiveProvider } from "../config.ts";
 import { listSkills } from "../skills.ts";
 
 const client = new Client({
@@ -209,6 +209,7 @@ async function buildChannelHistory(msg: Message): Promise<ChatMessage[]> {
 
 export async function startDiscord(): Promise<void> {
 const startupConfig = loadConfig();
+console.log(`[gateway] Active provider: ${getActiveProvider(startupConfig)}`);
 const discordCfg = startupConfig.channel?.discord;
 if (!discordCfg?.enabled) {
     return;


### PR DESCRIPTION
This PR fixes two issues:

1. **Reasoning parameter only for OpenRouter**: The  parameter is added unconditionally when . However, only OpenRouter supports this parameter. Custom providers (like Groq) return 400 errors. This PR adds a check: reasoning is only added when the active provider is OpenRouter.

2. **Log active provider on startup**: Added a console.log in  that prints the active provider (e.g., "custom", "openrouter") when the gateway starts. This helps users verify that their config is being read correctly.

These changes should resolve the "property reasoning is unsupported" error when using custom providers and give users visibility into which provider is actually being used.